### PR TITLE
ci: fix add commit action not using valid syntax

### DIFF
--- a/.github/workflows/refresh-samples.yaml
+++ b/.github/workflows/refresh-samples.yaml
@@ -21,11 +21,6 @@ jobs:
       - run: npm run linxo-test-bank
       - uses: EndBug/add-and-commit@v9
         with:
-          add:
-            - '*.json'
-            - 'linxo_test_bank/*.txt'
+          add: '["*.json", "linxo_test_bank/*.txt"]'
           push: true
           message: 'chore: 🤖 Automatically refreshed data samples'
-
-
-


### PR DESCRIPTION
Hello,

In a previous commit, I didn't understand what the author of the action `EndBug/add-and-commit` meant by ["JSON or YAML arrays"](https://github.com/EndBug/add-and-commit#adding-files), so I didn't configure the action correctly and provoked errors. This should work now. 

Thanks. 