### PR TITLE
[FIX] Fix wrong currency in raw data account

### DIFF
--- a/mappers/budgetInsightV20/accounts.ts
+++ b/mappers/budgetInsightV20/accounts.ts
@@ -8,7 +8,7 @@ export const algoanAccountsToBIAccounts = (): any => {
     last_update: account.balanceDate,
     iban: account.iban,
     currency: {
-      id: 'EUR',
+      id: account.currency,
     },
     type: getBIType(account.type),
     usage: getBIUsage(account.usage),

--- a/mappers/linxoV2/accounts.ts
+++ b/mappers/linxoV2/accounts.ts
@@ -16,7 +16,7 @@ const getAccountStr = (account: AccountsEntity, accountName: string): string => 
   '',                               // payment_source
   '',                               // payment_destination
   account.iban,                     // iban
-  'EUR'                             // currency
+  account.currency                  // currency
 ].join('|');
 
 /**


### PR DESCRIPTION
In the case of UK accounts, the currency should be `GBP` instead of `EUR`.
Since it is correctly set in the sample, only the wrong mappers needs to be fixed.