### PR TITLE
[FEAT] set default hour for account balance and transaction dates

### DIFF
--- a/.github/workflows/refresh-samples.yaml
+++ b/.github/workflows/refresh-samples.yaml
@@ -21,6 +21,6 @@ jobs:
       - run: npm run linxo-test-bank
       - uses: EndBug/add-and-commit@v9
         with:
-          add: '["*.json", "linxo_test_bank/*.txt"]'
+          add: '["*.json", "raw-data/linxo_test_bank/**/*.txt"]'
           push: true
           message: 'chore: 🤖 Automatically refreshed data samples'

--- a/.github/workflows/refresh-samples.yaml
+++ b/.github/workflows/refresh-samples.yaml
@@ -24,3 +24,5 @@ jobs:
           add: '["*.json", "raw-data/linxo_test_bank/**/*.txt"]'
           push: true
           message: 'chore: 🤖 Automatically refreshed data samples'
+          author_name: Algoan Bot
+          author_email: bot@algoan.com

--- a/scripts/index.ts
+++ b/scripts/index.ts
@@ -18,7 +18,7 @@ interface TransactionDates {
  * @param nbOfDayToAdd number of days to add
  */
 function addDays(date: string, nbOfDayToAdd: number): string {
-  return dayjs(date).add(nbOfDayToAdd, 'day').toISOString();
+  return dayjs(date).add(nbOfDayToAdd, 'day').set('hour', 14).toISOString();
 }
 
 /**
@@ -54,7 +54,7 @@ function mapTransactions(nbOfDayToAdd: number) {
 function mapAccount(nbOfDayToAdd: number) {
   return (account: AccountsEntity) => ({
     ...account,
-    balanceDate: dayjs(account.balanceDate).add(nbOfDayToAdd, 'day').toISOString(),
+    balanceDate: addDays(account.balanceDate, nbOfDayToAdd),
     transactions: account.transactions.map(mapTransactions(nbOfDayToAdd)),
   });
 }


### PR DESCRIPTION
# Description
This pull request aims to set a default hour for account balance and transaction dates.

I noticed github actions were failing for `linxo_test_bank` because the path to commit files was incorrect.
I also modified the commit author to algoan bot so it stops using ccoeurderoy identity.

# Documentation
The default value is `12:00:00Z` / `14:00:00+02:00`. 
A bug related to daylight saving time occurs and results having `12:00:00` and `13:00:00` depending on the date. An issue has been opened 3 years ago on [dayjs](https://github.com/iamkun/dayjs/issues/1260) but it has not been fixed.