### PR TITLE
[FEAT] modify date's default hour

### DIFF
--- a/.github/workflows/refresh-samples.yaml
+++ b/.github/workflows/refresh-samples.yaml
@@ -3,6 +3,9 @@ on:
   workflow_dispatch:
   schedule:
     - cron: '0 12 * * 1-5'
+  push:
+    branches:
+      - main
 
 jobs:
   run_script:

--- a/scripts/index.ts
+++ b/scripts/index.ts
@@ -18,7 +18,7 @@ interface TransactionDates {
  * @param nbOfDayToAdd number of days to add
  */
 function addDays(date: string, nbOfDayToAdd: number): string {
-  return dayjs(date).add(nbOfDayToAdd, 'day').set('hour', 14).toISOString();
+  return dayjs(date).add(nbOfDayToAdd, 'day').set('hour', 12).toISOString();
 }
 
 /**


### PR DESCRIPTION
# Description
In [my last pull request](https://github.com/algoan/fake-open-banking-data/pull/14), I set the date's default hour to 14:00:00 so it equals to 12:00:00 utc. 

I had to do this because my local environment uses Paris timezone, but it is not the case with CI's environment which uses UTC timezone. Thus the default value can be set to 12 instead of 14.

I also noticed the bug related to daylight saving time (DST) does not occur with CI because UTC timezone has no DST.