### PR TITLE
Create error samples

### DIFF
--- a/samples/fr/README.md
+++ b/samples/fr/README.md
@@ -182,3 +182,73 @@
 - Has light overdraft at end of month
 - Has standard expenses: power, telecom, transport, multimedia, gym
 - Has savings
+
+## Account type not supported
+
+**Language**: French 🇫🇷
+
+| Format                       | Link                                                                                                                                                       |
+| ---------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Algoan                       | [🔗](https://raw.githubusercontent.com/algoan/fake-open-banking-data/main/samples/fr/account_type_not_supported.json)                                      |
+| Budget Insight               | [🔗](https://raw.githubusercontent.com/algoan/fake-open-banking-data/main/raw-data/budget_insight_v2_0/fr/account_type_not_supported.json)                 |
+| Linxo Connect Direct Account | [🔗](https://raw.githubusercontent.com/algoan/fake-open-banking-data/main/raw-data/linxo_connect_direct_account_api_v3/fr/account_type_not_supported.json) |
+
+**Description**:
+
+This error occurs when there is not at least one checking account provided for the analysis.
+
+## Currency not supported
+
+**Language**: French 🇫🇷
+
+| Format                       | Link                                                                                                                                                   |
+| ---------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Algoan                       | [🔗](https://raw.githubusercontent.com/algoan/fake-open-banking-data/main/samples/fr/currency_not_supported.json)                                      |
+| Budget Insight               | [🔗](https://raw.githubusercontent.com/algoan/fake-open-banking-data/main/raw-data/budget_insight_v2_0/fr/currency_not_supported.json)                 |
+| Linxo Connect Direct Account | [🔗](https://raw.githubusercontent.com/algoan/fake-open-banking-data/main/raw-data/linxo_connect_direct_account_api_v3/fr/currency_not_supported.json) |
+
+**Description**:
+
+This error occurs when one account has a different currency from the one in the project's configuration.
+
+## No checking account
+
+**Language**: French 🇫🇷
+
+| Format                       | Link                                                                                                                                                |
+| ---------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Algoan                       | [🔗](https://raw.githubusercontent.com/algoan/fake-open-banking-data/main/samples/fr/no_checking_account.json)                                      |
+| Budget Insight               | [🔗](https://raw.githubusercontent.com/algoan/fake-open-banking-data/main/raw-data/budget_insight_v2_0/fr/no_checking_account.json)                 |
+| Linxo Connect Direct Account | [🔗](https://raw.githubusercontent.com/algoan/fake-open-banking-data/main/raw-data/linxo_connect_direct_account_api_v3/fr/no_checking_account.json) |
+
+**Description**:
+
+This error occurs if there is not at least one non-professional checking account provided for the analysis.
+
+## Not enough transactions
+
+**Language**: French 🇫🇷
+
+| Format                       | Link                                                                                                                                                    |
+| ---------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Algoan                       | [🔗](https://raw.githubusercontent.com/algoan/fake-open-banking-data/main/samples/fr/not_enough_transactions.json)                                      |
+| Budget Insight               | [🔗](https://raw.githubusercontent.com/algoan/fake-open-banking-data/main/raw-data/budget_insight_v2_0/fr/not_enough_transactions.json)                 |
+| Linxo Connect Direct Account | [🔗](https://raw.githubusercontent.com/algoan/fake-open-banking-data/main/raw-data/linxo_connect_direct_account_api_v3/fr/not_enough_transactions.json) |
+
+**Description**:
+
+This error occurs when there is not enough transactions to compute the analysis.
+
+## Ownership not supported
+
+**Language**: French 🇫🇷
+
+| Format                       | Link                                                                                                                                                    |
+| ---------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Algoan                       | [🔗](https://raw.githubusercontent.com/algoan/fake-open-banking-data/main/samples/fr/ownership_not_supported.json)                                      |
+| Budget Insight               | [🔗](https://raw.githubusercontent.com/algoan/fake-open-banking-data/main/raw-data/budget_insight_v2_0/fr/ownership_not_supported.json)                 |
+| Linxo Connect Direct Account | [🔗](https://raw.githubusercontent.com/algoan/fake-open-banking-data/main/raw-data/linxo_connect_direct_account_api_v3/fr/ownership_not_supported.json) |
+
+**Description**:
+
+This error occurs when there is not at least one account with an ownership different from 'ATTORNEY' provided for the analysis.

--- a/samples/fr/account_type_not_supported.json
+++ b/samples/fr/account_type_not_supported.json
@@ -1,0 +1,156 @@
+{
+  "accounts": [
+    {
+      "transactions": [
+        {
+          "amount": 100,
+          "description": "VIR SALAIRE ALGOAN",
+          "dates": {
+            "debitedAt": "2021-05-15T22:00:00Z"
+          },
+          "currency": "EUR"
+        },
+        {
+          "currency": "EUR",
+          "dates": {
+            "debitedAt": "2024-04-06T12:00:00.000Z"
+          },
+          "description": "PRELEVEMENT HARRY POTTER PRELEVEMENT CARTE ZERO FAST3280420323",
+          "amount": 101.67
+        },
+        {
+          "currency": "EUR",
+          "dates": {
+            "debitedAt": "2024-04-06T12:00:00.000Z"
+          },
+          "description": "PRLV SEPA POTTER HARRY ECH ID EMETTEUR/LU66ZZZ000023 MDT/3BEAC43A69zeeeeAC6 REF/1B0F18BC115A4788DA4 LIB/PRELEVEMENT CARTE ZERO FSSI043def106",
+          "amount": 150
+        },
+        {
+          "currency": "EUR",
+          "dates": {
+            "debitedAt": "2024-04-07T12:00:00.000Z"
+          },
+          "description": "PRELEVEMENT DE NAVIGO ANNUEL - G COMUTITRES REF : 3/262663-1/92921 Navigo Annuel",
+          "amount": 75.2
+        },
+        {
+          "currency": "EUR",
+          "dates": {
+            "debitedAt": "2024-04-07T12:00:00.000Z"
+          },
+          "description": "PRLV SEPA CREDIPAR Motif : 101M3323222 32 VOTRE IDEN",
+          "amount": 399.89
+        }
+      ],
+      "balance": 1457.16,
+      "balanceDate": "2023-08-31T12:00:00.000Z",
+      "iban": "FR1248145844888DDFQXKV7BY13",
+      "currency": "EUR",
+      "type": "UNKNOWN",
+      "usage": "PERSONAL",
+      "name": "Compte courant 01",
+      "bank": {
+        "name": "Algoan Demo",
+        "id": "AD",
+        "logoUrl": "https://storage.googleapis.com/bank-data-images-preprod/algoan-bank/logo.svg"
+      }
+    },
+    {
+      "transactions": [
+        {
+          "currency": "EUR",
+          "dates": {
+            "debitedAt": "2024-04-06T12:00:00.000Z"
+          },
+          "description": "PRELEVEMENT HARRY POTTER PRELEVEMENT CARTE ZERO FAST3280420323",
+          "amount": -101.67
+        },
+        {
+          "currency": "EUR",
+          "dates": {
+            "debitedAt": "2024-04-06T12:00:00.000Z"
+          },
+          "description": "PRLV SEPA POTTER HARRY ECH ID EMETTEUR/LU66ZZZ000023 MDT/3BEAC43A69zeeeeAC6 REF/1B0F18BC115A4788DA4 LIB/PRELEVEMENT CARTE ZERO FSSI043def106",
+          "amount": -150
+        },
+        {
+          "currency": "EUR",
+          "dates": {
+            "debitedAt": "2024-04-07T12:00:00.000Z"
+          },
+          "description": "PRELEVEMENT DE NAVIGO ANNUEL - G COMUTITRES REF : 3/262663-1/92921 Navigo Annuel",
+          "amount": -75.2
+        },
+        {
+          "currency": "EUR",
+          "dates": {
+            "debitedAt": "2024-04-07T12:00:00.000Z"
+          },
+          "description": "PRLV SEPA CREDIPAR Motif : 101M3323222 32 VOTRE IDEN",
+          "amount": -399.89
+        }
+      ],
+      "balance": -120,
+      "balanceDate": "2023-08-31T12:00:00.000Z",
+      "iban": "FR7158308147881N2Z8VVNBLU24",
+      "currency": "EUR",
+      "type": "UNKNOWN",
+      "usage": "PERSONAL",
+      "name": "Compte carte 01",
+      "bank": {
+        "name": "Algoan Demo",
+        "id": "AD",
+        "logoUrl": "https://storage.googleapis.com/bank-data-images-preprod/algoan-bank/logo.svg"
+      }
+    },
+    {
+      "transactions": [
+        {
+          "currency": "EUR",
+          "dates": {
+            "debitedAt": "2024-04-06T12:00:00.000Z"
+          },
+          "description": "PRELEVEMENT HARRY POTTER PRELEVEMENT CARTE ZERO FAST3280420323",
+          "amount": -101.67
+        },
+        {
+          "currency": "EUR",
+          "dates": {
+            "debitedAt": "2024-04-06T12:00:00.000Z"
+          },
+          "description": "PRLV SEPA POTTER HARRY ECH ID EMETTEUR/LU66ZZZ000023 MDT/3BEAC43A69zeeeeAC6 REF/1B0F18BC115A4788DA4 LIB/PRELEVEMENT CARTE ZERO FSSI043def106",
+          "amount": -150
+        },
+        {
+          "currency": "EUR",
+          "dates": {
+            "debitedAt": "2024-04-07T12:00:00.000Z"
+          },
+          "description": "PRELEVEMENT DE NAVIGO ANNUEL - G COMUTITRES REF : 3/262663-1/92921 Navigo Annuel",
+          "amount": -75.2
+        },
+        {
+          "currency": "EUR",
+          "dates": {
+            "debitedAt": "2024-04-07T12:00:00.000Z"
+          },
+          "description": "PRLV SEPA CREDIPAR Motif : 101M3323222 32 VOTRE IDEN",
+          "amount": -399.89
+        }
+      ],
+      "balance": 2200,
+      "balanceDate": "2023-08-31T12:00:00.000Z",
+      "iban": "FR195226475633NGNDOGOL7KZ15",
+      "currency": "EUR",
+      "type": "UNKNOWN",
+      "usage": "PERSONAL",
+      "name": "Compte épargne 01",
+      "bank": {
+        "name": "Algoan Demo",
+        "id": "AD",
+        "logoUrl": "https://storage.googleapis.com/bank-data-images-preprod/algoan-bank/logo.svg"
+      }
+    }
+  ]
+}

--- a/samples/fr/currency_not_supported.json
+++ b/samples/fr/currency_not_supported.json
@@ -1,0 +1,60 @@
+{
+  "accounts": [
+    {
+      "transactions": [
+        {
+          "amount": 1000,
+          "description": "VIR SALAIRE ALGOAN",
+          "dates": {
+            "debitedAt": "2021-05-15T22:00:00Z"
+          },
+          "currency": "USD"
+        },
+        {
+          "currency": "USD",
+          "dates": {
+            "debitedAt": "2024-04-06T12:00:00.000Z"
+          },
+          "description": "PRELEVEMENT HARRY POTTER PRELEVEMENT CARTE ZERO FAST3280420323",
+          "amount": 101.67
+        },
+        {
+          "currency": "USD",
+          "dates": {
+            "debitedAt": "2024-04-06T12:00:00.000Z"
+          },
+          "description": "PRLV SEPA POTTER HARRY ECH ID EMETTEUR/LU66ZZZ000023 MDT/3BEAC43A69zeeeeAC6 REF/1B0F18BC115A4788DA4 LIB/PRELEVEMENT CARTE ZERO FSSI043def106",
+          "amount": 150
+        },
+        {
+          "currency": "EUR",
+          "dates": {
+            "debitedAt": "2024-04-07T12:00:00.000Z"
+          },
+          "description": "PRELEVEMENT DE NAVIGO ANNUEL - G COMUTITRES REF : 3/262663-1/92921 Navigo Annuel",
+          "amount": 75.2
+        },
+        {
+          "currency": "USD",
+          "dates": {
+            "debitedAt": "2024-04-07T12:00:00.000Z"
+          },
+          "description": "PRLV SEPA CREDIPAR Motif : 101M3323222 32 VOTRE IDEN",
+          "amount": 399.89
+        }
+      ],
+      "balance": 1457.16,
+      "balanceDate": "2023-08-31T12:00:00.000Z",
+      "iban": "FR1958145846888DDFQXKV7CA18",
+      "currency": "USD",
+      "type": "CHECKING",
+      "usage": "PERSONAL",
+      "name": "Compte courant 01",
+      "bank": {
+        "name": "Algoan Demo",
+        "id": "AD",
+        "logoUrl": "https://storage.googleapis.com/bank-data-images-preprod/algoan-bank/logo.svg"
+      }
+    }
+  ]
+}

--- a/samples/fr/no_checking_account.json
+++ b/samples/fr/no_checking_account.json
@@ -1,0 +1,110 @@
+{
+  "accounts": [
+    {
+      "transactions": [
+        {
+          "amount": 1000,
+          "description": "VIR SALAIRE ALGOAN",
+          "dates": {
+            "debitedAt": "2021-05-15T22:00:00Z"
+          },
+          "currency": "EUR"
+        },
+        {
+          "currency": "EUR",
+          "dates": {
+            "debitedAt": "2024-04-06T12:00:00.000Z"
+          },
+          "description": "PRELEVEMENT HARRY POTTER PRELEVEMENT CARTE ZERO FAST3280420323",
+          "amount": 101.67
+        },
+        {
+          "currency": "EUR",
+          "dates": {
+            "debitedAt": "2024-04-06T12:00:00.000Z"
+          },
+          "description": "PRLV SEPA POTTER HARRY ECH ID EMETTEUR/LU66ZZZ000023 MDT/3BEAC43A69zeeeeAC6 REF/1B0F18BC115A4788DA4 LIB/PRELEVEMENT CARTE ZERO FSSI043def106",
+          "amount": 150
+        },
+        {
+          "currency": "EUR",
+          "dates": {
+            "debitedAt": "2024-04-07T12:00:00.000Z"
+          },
+          "description": "PRELEVEMENT DE NAVIGO ANNUEL - G COMUTITRES REF : 3/262663-1/92921 Navigo Annuel",
+          "amount": 75.2
+        },
+        {
+          "currency": "EUR",
+          "dates": {
+            "debitedAt": "2024-04-07T12:00:00.000Z"
+          },
+          "description": "PRLV SEPA CREDIPAR Motif : 101M3323222 32 VOTRE IDEN",
+          "amount": 399.89
+        }
+      ],
+      "balance": 1457.16,
+      "balanceDate": "2023-08-31T12:00:00.000Z",
+      "iban": "FR1243145855666DDFQXKV7BY13",
+      "currency": "EUR",
+      "type": "SAVINGS",
+      "usage": "PERSONAL",
+      "name": "Compte courant 01",
+      "bank": {
+        "name": "Algoan Demo",
+        "id": "AD",
+        "logoUrl": "https://storage.googleapis.com/bank-data-images-preprod/algoan-bank/logo.svg"
+      }
+    },
+    {
+      "transactions": [
+        {
+          "currency": "EUR",
+          "dates": {
+            "debitedAt": "2024-04-06T12:00:00.000Z"
+          },
+          "description": "PRELEVEMENT HARRY POTTER PRELEVEMENT CARTE ZERO FAST3280420323",
+          "amount": -101.67
+        },
+        {
+          "currency": "EUR",
+          "dates": {
+            "debitedAt": "2024-04-06T12:00:00.000Z"
+          },
+          "description": "PRLV SEPA POTTER HARRY ECH ID EMETTEUR/LU66ZZZ000023 MDT/3BEAC43A69zeeeeAC6 REF/1B0F18BC115A4788DA4 LIB/PRELEVEMENT CARTE ZERO FSSI043def106",
+          "amount": -150
+        },
+        {
+          "currency": "EUR",
+          "dates": {
+            "debitedAt": "2024-04-07T12:00:00.000Z"
+          },
+          "description": "PRELEVEMENT DE NAVIGO ANNUEL - G COMUTITRES REF : 3/262663-1/92921 Navigo Annuel",
+          "amount": -75.2
+        },
+        {
+          "currency": "EUR",
+          "dates": {
+            "debitedAt": "2024-04-07T12:00:00.000Z"
+          },
+          "description": "PRLV SEPA CREDIPAR Motif : 101M3323222 32 VOTRE IDEN",
+          "amount": -399.89
+        }
+      ],
+      "balance": -120,
+      "balanceDate": "2023-08-31T12:00:00.000Z",
+      "iban": "FR7158308147881N2Z8VVNBLU24",
+      "currency": "EUR",
+      "type": "LOAN",
+      "usage": "PERSONAL",
+      "ownership": "ATTORNEY",
+      "id": 924,
+      "name": "Compte carte 01",
+      "bank": {
+        "name": "Algoan Demo",
+        "id": "AD",
+        "logoUrl": "https://storage.googleapis.com/bank-data-images-preprod/algoan-bank/logo.svg"
+      }
+    }
+  ]
+}

--- a/samples/fr/not_enough_transactions.json
+++ b/samples/fr/not_enough_transactions.json
@@ -1,0 +1,36 @@
+{
+  "accounts": [
+    {
+      "transactions": [],
+      "balance": 1457.16,
+      "balanceDate": "2023-08-31T12:00:00.000Z",
+      "iban": "FR1248145844888DDFQXKV7BY13",
+      "currency": "EUR",
+      "type": "CHECKING",
+      "usage": "PERSONAL",
+      "name": "Compte courant 01",
+      "bank": {
+        "name": "Algoan Demo",
+        "id": "AD",
+        "logoUrl": "https://storage.googleapis.com/bank-data-images-preprod/algoan-bank/logo.svg"
+      }
+    },
+    {
+      "transactions": [],
+      "balance": -120,
+      "balanceDate": "2023-08-31T12:00:00.000Z",
+      "iban": "FR7158308147881N2Z8VVNBLU24",
+      "currency": "EUR",
+      "type": "LOAN",
+      "usage": "PERSONAL",
+      "ownership": "ATTORNEY",
+      "id": 924,
+      "name": "Compte carte 01",
+      "bank": {
+        "name": "Algoan Demo",
+        "id": "AD",
+        "logoUrl": "https://storage.googleapis.com/bank-data-images-preprod/algoan-bank/logo.svg"
+      }
+    }
+  ]
+}

--- a/samples/fr/ownership_not_supported.json
+++ b/samples/fr/ownership_not_supported.json
@@ -1,0 +1,154 @@
+{
+  "accounts": [
+    {
+      "transactions": [
+        {
+          "currency": "EUR",
+          "dates": {
+            "debitedAt": "2024-04-06T12:00:00.000Z"
+          },
+          "description": "PRELEVEMENT HARRY POTTER PRELEVEMENT CARTE ZERO FAST3280420323",
+          "amount": -101.67
+        },
+        {
+          "currency": "EUR",
+          "dates": {
+            "debitedAt": "2024-04-06T12:00:00.000Z"
+          },
+          "description": "PRLV SEPA POTTER HARRY ECH ID EMETTEUR/LU66ZZZ000023 MDT/3BEAC43A69zeeeeAC6 REF/1B0F18BC115A4788DA4 LIB/PRELEVEMENT CARTE ZERO FSSI043def106",
+          "amount": -150
+        },
+        {
+          "currency": "EUR",
+          "dates": {
+            "debitedAt": "2024-04-07T12:00:00.000Z"
+          },
+          "description": "PRELEVEMENT DE NAVIGO ANNUEL - G COMUTITRES REF : 3/262663-1/92921 Navigo Annuel",
+          "amount": -75.2
+        },
+        {
+          "currency": "EUR",
+          "dates": {
+            "debitedAt": "2024-04-07T12:00:00.000Z"
+          },
+          "description": "PRLV SEPA CREDIPAR Motif : 101M3323222 32 VOTRE IDEN",
+          "amount": -399.89
+        }
+      ],
+      "balance": 1457.16,
+      "balanceDate": "2023-08-31T12:00:00.000Z",
+      "iban": "FR4328145844333SDFQXKV7BY21",
+      "currency": "EUR",
+      "type": "CHECKING",
+      "usage": "PERSONAL",
+      "id": 3,
+      "name": "Compte courant 01",
+      "ownership": "ATTORNEY",
+      "bank": {
+        "name": "Algoan Demo",
+        "id": "AD",
+        "logoUrl": "https://storage.googleapis.com/bank-data-images-preprod/algoan-bank/logo.svg"
+      }
+    },
+    {
+      "transactions": [
+        {
+          "currency": "EUR",
+          "dates": {
+            "debitedAt": "2024-04-06T12:00:00.000Z"
+          },
+          "description": "PRELEVEMENT HARRY POTTER PRELEVEMENT CARTE ZERO FAST3280420323",
+          "amount": -101.67
+        },
+        {
+          "currency": "EUR",
+          "dates": {
+            "debitedAt": "2024-04-06T12:00:00.000Z"
+          },
+          "description": "PRLV SEPA POTTER HARRY ECH ID EMETTEUR/LU66ZZZ000023 MDT/3BEAC43A69zeeeeAC6 REF/1B0F18BC115A4788DA4 LIB/PRELEVEMENT CARTE ZERO FSSI043def106",
+          "amount": -150
+        },
+        {
+          "currency": "EUR",
+          "dates": {
+            "debitedAt": "2024-04-07T12:00:00.000Z"
+          },
+          "description": "PRELEVEMENT DE NAVIGO ANNUEL - G COMUTITRES REF : 3/262663-1/92921 Navigo Annuel",
+          "amount": -75.2
+        },
+        {
+          "currency": "EUR",
+          "dates": {
+            "debitedAt": "2024-04-07T12:00:00.000Z"
+          },
+          "description": "PRLV SEPA CREDIPAR Motif : 101M3323222 32 VOTRE IDEN",
+          "amount": -399.89
+        }
+      ],
+      "balance": -120,
+      "balanceDate": "2023-08-31T12:00:00.000Z",
+      "iban": "FR7158308147881N2Z8VVNBLU24",
+      "currency": "EUR",
+      "type": "CHECKING",
+      "usage": "PERSONAL",
+      "ownership": "ATTORNEY",
+      "id": 924,
+      "name": "Compte carte 01",
+      "bank": {
+        "name": "Algoan Demo",
+        "id": "AD",
+        "logoUrl": "https://storage.googleapis.com/bank-data-images-preprod/algoan-bank/logo.svg"
+      }
+    },
+    {
+      "transactions": [
+        {
+          "currency": "EUR",
+          "dates": {
+            "debitedAt": "2024-04-06T12:00:00.000Z"
+          },
+          "description": "PRELEVEMENT HARRY POTTER PRELEVEMENT CARTE ZERO FAST3280420323",
+          "amount": -101.67
+        },
+        {
+          "currency": "EUR",
+          "dates": {
+            "debitedAt": "2024-04-06T12:00:00.000Z"
+          },
+          "description": "PRLV SEPA POTTER HARRY ECH ID EMETTEUR/LU66ZZZ000023 MDT/3BEAC43A69zeeeeAC6 REF/1B0F18BC115A4788DA4 LIB/PRELEVEMENT CARTE ZERO FSSI043def106",
+          "amount": -150
+        },
+        {
+          "currency": "EUR",
+          "dates": {
+            "debitedAt": "2024-04-07T12:00:00.000Z"
+          },
+          "description": "PRELEVEMENT DE NAVIGO ANNUEL - G COMUTITRES REF : 3/262663-1/92921 Navigo Annuel",
+          "amount": -75.2
+        },
+        {
+          "currency": "EUR",
+          "dates": {
+            "debitedAt": "2024-04-07T12:00:00.000Z"
+          },
+          "description": "PRLV SEPA CREDIPAR Motif : 101M3323222 32 VOTRE IDEN",
+          "amount": -399.89
+        }
+      ],
+      "balance": 2200,
+      "balanceDate": "2023-08-31T12:00:00.000Z",
+      "iban": "FR195226475633NGNDOGOL7KZ15",
+      "currency": "EUR",
+      "type": "CHECKING",
+      "usage": "PERSONAL",
+      "ownership": "ATTORNEY",
+      "id": 183,
+      "name": "Compte épargne 01",
+      "bank": {
+        "name": "Algoan Demo",
+        "id": "AD",
+        "logoUrl": "https://storage.googleapis.com/bank-data-images-preprod/algoan-bank/logo.svg"
+      }
+    }
+  ]
+}

--- a/samples/fr/usage_not_supported.json
+++ b/samples/fr/usage_not_supported.json
@@ -1,0 +1,110 @@
+{
+  "accounts": [
+    {
+      "transactions": [
+        {
+          "amount": 1000,
+          "description": "VIR SALAIRE ALGOAN",
+          "dates": {
+            "debitedAt": "2021-05-15T22:00:00Z"
+          },
+          "currency": "EUR"
+        },
+        {
+          "currency": "EUR",
+          "dates": {
+            "debitedAt": "2024-04-06T12:00:00.000Z"
+          },
+          "description": "PRELEVEMENT HARRY POTTER PRELEVEMENT CARTE ZERO FAST3280420323",
+          "amount": 101.67
+        },
+        {
+          "currency": "EUR",
+          "dates": {
+            "debitedAt": "2024-04-06T12:00:00.000Z"
+          },
+          "description": "PRLV SEPA POTTER HARRY ECH ID EMETTEUR/LU66ZZZ000023 MDT/3BEAC43A69zeeeeAC6 REF/1B0F18BC115A4788DA4 LIB/PRELEVEMENT CARTE ZERO FSSI043def106",
+          "amount": 150
+        },
+        {
+          "currency": "EUR",
+          "dates": {
+            "debitedAt": "2024-04-07T12:00:00.000Z"
+          },
+          "description": "PRELEVEMENT DE NAVIGO ANNUEL - G COMUTITRES REF : 3/262663-1/92921 Navigo Annuel",
+          "amount": 75.2
+        },
+        {
+          "currency": "EUR",
+          "dates": {
+            "debitedAt": "2024-04-07T12:00:00.000Z"
+          },
+          "description": "PRLV SEPA CREDIPAR Motif : 101M3323222 32 VOTRE IDEN",
+          "amount": 399.89
+        }
+      ],
+      "balance": 1457.16,
+      "balanceDate": "2023-08-31T12:00:00.000Z",
+      "iban": "FR7848145834999DDFQYZV7BY13",
+      "currency": "EUR",
+      "type": "CHECKING",
+      "usage": "PROFESSIONAL",
+      "name": "Compte courant 01",
+      "bank": {
+        "name": "Algoan Demo",
+        "id": "AD",
+        "logoUrl": "https://storage.googleapis.com/bank-data-images-preprod/algoan-bank/logo.svg"
+      }
+    },
+    {
+      "transactions": [
+        {
+          "currency": "EUR",
+          "dates": {
+            "debitedAt": "2024-04-06T12:00:00.000Z"
+          },
+          "description": "PRELEVEMENT HARRY POTTER PRELEVEMENT CARTE ZERO FAST3280420323",
+          "amount": -101.67
+        },
+        {
+          "currency": "EUR",
+          "dates": {
+            "debitedAt": "2024-04-06T12:00:00.000Z"
+          },
+          "description": "PRLV SEPA POTTER HARRY ECH ID EMETTEUR/LU66ZZZ000023 MDT/3BEAC43A69zeeeeAC6 REF/1B0F18BC115A4788DA4 LIB/PRELEVEMENT CARTE ZERO FSSI043def106",
+          "amount": -150
+        },
+        {
+          "currency": "EUR",
+          "dates": {
+            "debitedAt": "2024-04-07T12:00:00.000Z"
+          },
+          "description": "PRELEVEMENT DE NAVIGO ANNUEL - G COMUTITRES REF : 3/262663-1/92921 Navigo Annuel",
+          "amount": -75.2
+        },
+        {
+          "currency": "EUR",
+          "dates": {
+            "debitedAt": "2024-04-07T12:00:00.000Z"
+          },
+          "description": "PRLV SEPA CREDIPAR Motif : 101M3323222 32 VOTRE IDEN",
+          "amount": -399.89
+        }
+      ],
+      "balance": -120,
+      "balanceDate": "2023-08-31T12:00:00.000Z",
+      "iban": "FR7158308147881N2Z8VVNBLU24",
+      "currency": "EUR",
+      "type": "LOAN",
+      "usage": "PROFESSIONAL",
+      "ownership": "ATTORNEY",
+      "id": 924,
+      "name": "Compte carte 01",
+      "bank": {
+        "name": "Algoan Demo",
+        "id": "AD",
+        "logoUrl": "https://storage.googleapis.com/bank-data-images-preprod/algoan-bank/logo.svg"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
# Documentation

This PR adds samples for different types of errors.
List of added errors : 

- `ACCOUNT_TYPE_NOT_SUPPORTED`
- `CURRENCY_NOT_SUPPORTED`
- `NO_CHECKING_ACCOUNT`
- `NOT_ENOUGH_TRANSACTIONS`
- `OWNERSHIP_NOT_SUPPORTED`
- `USAGE_NOT_SUPPORTED`
