### PR TITLE
[FIX] Fix converter error on new languages

### DIFF
--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,6 +1,5 @@
-import { readdirSync, readFileSync, writeFileSync } from 'fs';
-import * as path from 'path';
-
+import { readdirSync, readFileSync, writeFileSync } from 'node:fs';
+import * as path from 'node:path';
 import { FileEntity } from '../types';
 
 /**

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,4 +1,4 @@
-import { readdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { mkdirSync, readdirSync, readFileSync, writeFileSync } from 'node:fs';
 import * as path from 'node:path';
 import { FileEntity } from '../types';
 
@@ -37,13 +37,24 @@ export function readJSONFiles(dirPath: string): FileEntity[] {
 }
 
 /**
+ * Ensure the directory of a file path exist
+ * @param filePath the file to be created
+ */
+export function ensureDir(filePath: string): void {
+  mkdirSync(path.dirname(filePath), { recursive: true });
+}
+
+/**
  * Rewrite JSON samples with the refresh data
  * @param fileEntities Refresh sample file with file names
  * @param dirPath Samples directory path
  */
 export function writeJSONFiles(fileEntities: FileEntity[], dirName: string): void {
   fileEntities.forEach((fileEntity: FileEntity) => {
-    writeFileSync(`${dirName}/${fileEntity.filename}`, JSON.stringify(fileEntity.sample, null, 2));
+    const filepath: string = `${dirName}/${fileEntity.filename}`;
+
+    ensureDir(filepath);
+    writeFileSync(filepath, JSON.stringify(fileEntity.sample, null, 2));
   });
 }
 

--- a/mappers/linxoV2/accounts.ts
+++ b/mappers/linxoV2/accounts.ts
@@ -2,6 +2,7 @@ import dayjs from 'dayjs';
 import { makeId } from '../../lib/utils';
 import { AccountsEntity } from '../../types';
 
+// prettier-ignore
 const getAccountStr = (account: AccountsEntity, accountName: string): string => [
   'ACCOUNT',                        // model name
   makeId(12),                       // account_uid

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "dayjs": "^1.11.0"
       },
       "devDependencies": {
+        "@types/node": "^25.6.0",
         "prettier": "^2.6.0",
         "ts-node": "^10.7.0",
         "typescript": "^4.6.2"
@@ -63,11 +64,15 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "17.0.21",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.21.tgz",
-      "integrity": "sha512-DBZCJbhII3r90XbQxI8Y9IjjiiOGlZ0Hr32omXIZvwwZ7p4DMMXGrKXVyPfuoBOri9XNtL0UK69jYIBIsRX3QQ==",
+      "version": "25.6.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
+      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
       "dev": true,
-      "peer": true
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "undici-types": "~7.19.0"
+      }
     },
     "node_modules/acorn": {
       "version": "8.7.0",
@@ -185,6 +190,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.2.tgz",
       "integrity": "sha512-HM/hFigTBHZhLXshn9sN37H085+hQGeJHJ/X7LpBWLID/fbc2acUMfU+lGD98X81sKP+pFa9f0DZmCwB9GnbAg==",
       "dev": true,
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -192,6 +198,13 @@
       "engines": {
         "node": ">=4.2.0"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "7.19.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
+      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/v8-compile-cache-lib": {
       "version": "3.0.0",
@@ -250,11 +263,14 @@
       "dev": true
     },
     "@types/node": {
-      "version": "17.0.21",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.21.tgz",
-      "integrity": "sha512-DBZCJbhII3r90XbQxI8Y9IjjiiOGlZ0Hr32omXIZvwwZ7p4DMMXGrKXVyPfuoBOri9XNtL0UK69jYIBIsRX3QQ==",
+      "version": "25.6.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
+      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
       "dev": true,
-      "peer": true
+      "peer": true,
+      "requires": {
+        "undici-types": "~7.19.0"
+      }
     },
     "acorn": {
       "version": "8.7.0",
@@ -328,6 +344,13 @@
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.2.tgz",
       "integrity": "sha512-HM/hFigTBHZhLXshn9sN37H085+hQGeJHJ/X7LpBWLID/fbc2acUMfU+lGD98X81sKP+pFa9f0DZmCwB9GnbAg==",
+      "dev": true,
+      "peer": true
+    },
+    "undici-types": {
+      "version": "7.19.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
+      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
       "dev": true
     },
     "v8-compile-cache-lib": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "author": "ccoeurderoy",
   "license": "ISC",
   "devDependencies": {
+    "@types/node": "^25.6.0",
     "prettier": "^2.6.0",
     "ts-node": "^10.7.0",
     "typescript": "^4.6.2"

--- a/scripts/converter.ts
+++ b/scripts/converter.ts
@@ -1,5 +1,4 @@
-import * as path from 'path';
-
+import * as path from 'node:path';
 import { readJSONFiles, writeJSONFiles } from '../lib/utils';
 import { algoanAccountsToBIAccounts } from '../mappers/budgetInsightV20/accounts';
 import { algoanAccountsToLinxoAccounts } from '../mappers/linxoDAV3/accounts';

--- a/scripts/index.ts
+++ b/scripts/index.ts
@@ -1,7 +1,6 @@
+import * as path from 'node:path';
 import dayjs from 'dayjs';
-import * as path from 'path';
 import { readJSONFiles, writeJSONFiles } from '../lib/utils';
-
 import { AccountsEntity, FileEntity, Sample, TransactionsEntity } from '../types';
 
 /**

--- a/scripts/linxo-test-bank.ts
+++ b/scripts/linxo-test-bank.ts
@@ -1,6 +1,6 @@
 import { writeFileSync } from 'node:fs';
 import * as path from 'node:path';
-import { readJSONFiles } from '../lib/utils';
+import { ensureDir, readJSONFiles } from '../lib/utils';
 import { getTextStringFromAcc } from '../mappers/linxoV2/accounts';
 import { FileEntity } from '../types';
 
@@ -14,6 +14,9 @@ import { FileEntity } from '../types';
   for (const file of fileEntities) {
     const txtStr: string = await getTextStringFromAcc(file.sample.accounts);
     const newFileName: string = file.filename.replace('.json', '.txt');
-    writeFileSync(path.join(__dirname, '..', 'raw-data/linxo_test_bank/', newFileName), txtStr);
+    const newFilePath: string = path.join(__dirname, '..', 'raw-data/linxo_test_bank/', newFileName);
+
+    ensureDir(newFilePath);
+    writeFileSync(newFilePath, txtStr);
   }
 })();

--- a/scripts/linxo-test-bank.ts
+++ b/scripts/linxo-test-bank.ts
@@ -1,8 +1,8 @@
-import { getTextStringFromAcc } from '../mappers/linxoV2/accounts';
-import { writeFileSync } from 'fs';
-import * as path from 'path';
-import { FileEntity } from '../types';
+import { writeFileSync } from 'node:fs';
+import * as path from 'node:path';
 import { readJSONFiles } from '../lib/utils';
+import { getTextStringFromAcc } from '../mappers/linxoV2/accounts';
+import { FileEntity } from '../types';
 
 (async function () {
   /**


### PR DESCRIPTION
### Description

Fix converter error on new languages.

Unexisting directories make the scripts crash.
We now ensure the directory exist before writing the files.

```ts
Error: ENOENT: no such file or directory, open '/home/runner/work/fake-open-banking-data/fake-open-banking-data/raw-data/budget_insight_v2_0/nl/sarah_connor.json'
    at Object.openSync (node:fs:590:3)
    at writeFileSync (node:fs:2202:35)
    at /home/runner/work/fake-open-banking-data/fake-open-banking-data/lib/utils.ts:47:18
    at Array.forEach (<anonymous>)
    at writeJSONFiles (/home/runner/work/fake-open-banking-data/fake-open-banking-data/lib/utils.ts:46:16)
    at /home/runner/work/fake-open-banking-data/fake-open-banking-data/scripts/converter.ts:67:19
    at Object.<anonymous> (/home/runner/work/fake-open-banking-data/fake-open-banking-data/scripts/converter.ts:69:3)
    at Module._compile (node:internal/modules/cjs/loader:1198:14)
    at Module.m._compile (/home/runner/work/fake-open-banking-data/fake-open-banking-data/node_modules/ts-node/src/index.ts:1455:23)
    at Module._extensions..js (node:internal/modules/cjs/loader:1252:10) {
  errno: -2,
  syscall: 'open',
  code: 'ENOENT',
  path: '/home/runner/work/fake-open-banking-data/fake-open-banking-data/raw-data/budget_insight_v2_0/nl/sarah_connor.json'
}
```
#### References

- Failed CI: https://github.com/algoan/fake-open-banking-data/actions/runs/25420297210/job/74560680716