### PR TITLE
feat: add a profile without an owner name

### DIFF
--- a/samples/fr/no_owner_name.json
+++ b/samples/fr/no_owner_name.json
@@ -1,0 +1,421 @@
+{
+  "accounts": [
+    {
+      "name": "Compte Courant 01",
+      "balance": 2633.03,
+      "balanceDate": "2026-05-12T12:00:00.000Z",
+      "bank": {
+        "name": "Algoan Demo",
+        "id": "AD",
+        "logoUrl": "https://storage.googleapis.com/bank-data-images-preprod/algoan-bank/logo.svg"
+      },
+      "currency": "EUR",
+      "transactions": [
+        {
+          "currency": "EUR",
+          "dates": {
+            "debitedAt": "2026-02-14T12:00:00.000Z"
+          },
+          "description": "PRELEVEMENT CRCAM CENTRE LOIRE 0224392 COTISATION D'ASSURANCE PACIFICA DU CONTRAT AUTOMOBILE 4 ROUES 302023131",
+          "amount": -101.74
+        },
+        {
+          "currency": "EUR",
+          "dates": {
+            "debitedAt": "2026-02-14T12:00:00.000Z"
+          },
+          "description": "PRELVT SEPA RECU D/O CONFRERE PRLV SEPA COFIDIS ICS.FR28ZZZ12211.RUM.80152131E12A SDR102112127",
+          "amount": -50.12
+        },
+        {
+          "currency": "EUR",
+          "dates": {
+            "debitedAt": "2026-02-14T12:00:00.000Z"
+          },
+          "description": "PRLV SEPA CREDIPAR Motif : 101M3323222 32 VOTRE IDEN",
+          "amount": -78.89
+        },
+        {
+          "currency": "EUR",
+          "dates": {
+            "debitedAt": "2026-02-15T12:00:00.000Z"
+          },
+          "description": "Cb 4978******304034 Tot Dif",
+          "amount": -989.34
+        },
+        {
+          "currency": "EUR",
+          "dates": {
+            "debitedAt": "2026-02-16T12:00:00.000Z"
+          },
+          "description": "PRELEVEMENT COFIDIS COF GEC-01 PLV ECHEANCE",
+          "amount": -17
+        },
+        {
+          "currency": "EUR",
+          "dates": {
+            "debitedAt": "2026-02-16T12:00:00.000Z"
+          },
+          "description": "PRET IMMOBILIER ECH",
+          "amount": -522.31
+        },
+        {
+          "currency": "EUR",
+          "dates": {
+            "debitedAt": "2026-02-16T12:00:00.000Z"
+          },
+          "description": "REGLEMENT ASSU. CNP PRET HABITAT",
+          "amount": -17.8
+        },
+        {
+          "currency": "EUR",
+          "dates": {
+            "debitedAt": "2026-02-17T12:00:00.000Z"
+          },
+          "description": "Cotisation Compte A Composer (rem = 20%)",
+          "amount": -13
+        },
+        {
+          "currency": "EUR",
+          "dates": {
+            "debitedAt": "2026-02-21T12:00:00.000Z"
+          },
+          "description": "PRELEVEMENT DE LUKO COVER SAS REF : 2RQ0IPC LUKO COVER SAS",
+          "amount": -20
+        },
+        {
+          "currency": "EUR",
+          "dates": {
+            "debitedAt": "2026-02-26T12:00:00.000Z"
+          },
+          "description": "PRLV SEPA CREDIPAR 10600220302032 32 VOTRE IDE FR0004123032023",
+          "amount": -122.45
+        },
+        {
+          "currency": "EUR",
+          "dates": {
+            "debitedAt": "2026-03-03T12:00:00.000Z"
+          },
+          "description": "CARTE X2517 A 06H23 RETRAIT DAB LA BANQUE POSTALE",
+          "amount": -120
+        },
+        {
+          "currency": "EUR",
+          "dates": {
+            "debitedAt": "2026-03-03T12:00:00.000Z"
+          },
+          "description": "PRELEVEMENT DE BOUYGUES TELECOM YGUES TELECOM REF : PAGP0102EAAE 06xxxxx685",
+          "amount": -15.99
+        },
+        {
+          "currency": "EUR",
+          "dates": {
+            "debitedAt": "2026-03-10T12:00:00.000Z"
+          },
+          "description": "VIR SEPA RECU /DE NEFAB /MOTIF VIREMENT NEFAB SAS /REF NEFABSAS-0000-082020092555-21",
+          "amount": 2581.45
+        },
+        {
+          "currency": "EUR",
+          "dates": {
+            "debitedAt": "2026-03-13T12:00:00.000Z"
+          },
+          "description": "PRELEVEMENT DE EDF CLIENTS PARTI iers REF : Z012201022 00203 1 S 114",
+          "amount": -102.32
+        },
+        {
+          "currency": "EUR",
+          "dates": {
+            "debitedAt": "2026-03-13T12:00:00.000Z"
+          },
+          "description": "PRLV SEPA BASIC FIT II SA ECH/ID EMETTEUR/FR10ZZ3122 MDT/737001831 REF/NO737001831-106 LIB",
+          "amount": -35.97
+        },
+        {
+          "currency": "EUR",
+          "dates": {
+            "debitedAt": "2026-03-16T12:00:00.000Z"
+          },
+          "description": "PRELEVEMENT CRCAM CENTRE LOIRE 0224392 COTISATION D'ASSURANCE PACIFICA DU CONTRAT AUTOMOBILE 4 ROUES 302023132",
+          "amount": -101.74
+        },
+        {
+          "currency": "EUR",
+          "dates": {
+            "debitedAt": "2026-03-16T12:00:00.000Z"
+          },
+          "description": "PRELVT SEPA RECU D/O CONFRERE PRLV SEPA COFIDIS ICS.FR28ZZZ12211.RUM.80152131E12A SDR102112128",
+          "amount": -50.12
+        },
+        {
+          "currency": "EUR",
+          "dates": {
+            "debitedAt": "2026-03-16T12:00:00.000Z"
+          },
+          "description": "PRLV SEPA CREDIPAR Motif : 101M3323222 32 VOTRE IDEN",
+          "amount": -78.89
+        },
+        {
+          "currency": "EUR",
+          "dates": {
+            "debitedAt": "2026-03-18T12:00:00.000Z"
+          },
+          "description": "Cb 4978******304034 Tot Dif",
+          "amount": -1233.21
+        },
+        {
+          "currency": "EUR",
+          "dates": {
+            "debitedAt": "2026-03-20T12:00:00.000Z"
+          },
+          "description": "REGLEMENT ASSU. CNP PRET HABITAT",
+          "amount": -17.8
+        },
+        {
+          "currency": "EUR",
+          "dates": {
+            "debitedAt": "2026-03-20T12:00:00.000Z"
+          },
+          "description": "Cotisation Compte A Composer (rem = 20%)",
+          "amount": -13
+        },
+        {
+          "currency": "EUR",
+          "dates": {
+            "debitedAt": "2026-03-20T12:00:00.000Z"
+          },
+          "description": "PRET IMMOBILIER ECH",
+          "amount": -522.31
+        },
+        {
+          "currency": "EUR",
+          "dates": {
+            "debitedAt": "2026-03-21T12:00:00.000Z"
+          },
+          "description": "PRELEVEMENT COFIDIS COF GEC-01 PLV ECHEANCE",
+          "amount": -19
+        },
+        {
+          "currency": "EUR",
+          "dates": {
+            "debitedAt": "2026-03-24T12:00:00.000Z"
+          },
+          "description": "CARTE X2517 3-4X CB ONEY. COMMERCE ELECTRONIQUE",
+          "amount": -126.99
+        },
+        {
+          "currency": "EUR",
+          "dates": {
+            "debitedAt": "2026-03-24T12:00:00.000Z"
+          },
+          "description": "PRELEVEMENT DE LUKO COVER SAS REF : 2RQ0IPC LUKO COVER SAS",
+          "amount": -20
+        },
+        {
+          "currency": "EUR",
+          "dates": {
+            "debitedAt": "2026-03-26T12:00:00.000Z"
+          },
+          "description": "PRLV SEPA CREDIPAR 10600220302032 32 VOTRE IDE FR0004123032023",
+          "amount": -122.45
+        },
+        {
+          "currency": "EUR",
+          "dates": {
+            "debitedAt": "2026-03-27T12:00:00.000Z"
+          },
+          "description": "PRLV SEPA CREDIPAR 10600220302032 32 VOTRE IDE FR0004123032023",
+          "amount": -122.45
+        },
+        {
+          "currency": "EUR",
+          "dates": {
+            "debitedAt": "2026-04-02T12:00:00.000Z"
+          },
+          "description": "ACHAT CB CARREFOUR DAC CARTE NUMERO 360",
+          "amount": -72.1
+        },
+        {
+          "currency": "EUR",
+          "dates": {
+            "debitedAt": "2026-04-03T12:00:00.000Z"
+          },
+          "description": "CARTE X2517 A 8H55 RETRAIT DAB LA BANQUE POSTALE",
+          "amount": -100
+        },
+        {
+          "currency": "EUR",
+          "dates": {
+            "debitedAt": "2026-04-04T12:00:00.000Z"
+          },
+          "description": "ACHAT CB CARREFOUR DAC CARTE NUMERO 360",
+          "amount": -78.9
+        },
+        {
+          "currency": "EUR",
+          "dates": {
+            "debitedAt": "2026-04-04T12:00:00.000Z"
+          },
+          "description": "PRELEVEMENT DE BOUYGUES TELECOM YGUES TELECOM REF : PAGP0102EAAE 06xxxxx686",
+          "amount": -15.99
+        },
+        {
+          "currency": "EUR",
+          "dates": {
+            "debitedAt": "2026-04-05T12:00:00.000Z"
+          },
+          "description": "ACHAT CB CARREFOUR DAC CARTE NUMERO 360",
+          "amount": -12
+        },
+        {
+          "currency": "EUR",
+          "dates": {
+            "debitedAt": "2026-04-11T12:00:00.000Z"
+          },
+          "description": "VIR SEPA RECU /DE NEFAB /MOTIF VIREMENT NEFAB SAS /REF NEFABSAS-0000-082020092555-21",
+          "amount": 2581.45
+        },
+        {
+          "currency": "EUR",
+          "dates": {
+            "debitedAt": "2026-04-13T12:00:00.000Z"
+          },
+          "description": "PRELEVEMENT DE EDF CLIENTS PARTI iers REF : Z012201022 00203 1 S 115",
+          "amount": -102.32
+        },
+        {
+          "currency": "EUR",
+          "dates": {
+            "debitedAt": "2026-04-13T12:00:00.000Z"
+          },
+          "description": "PRLV SEPA BASIC FIT II SA ECH/ID EMETTEUR/FR10ZZ3122 MDT/737001831 REF/NO737001831-106 LIB",
+          "amount": -35.97
+        },
+        {
+          "currency": "EUR",
+          "dates": {
+            "debitedAt": "2026-04-15T12:00:00.000Z"
+          },
+          "description": "PRELEVEMENT COFIDIS COF GEC-01 PLV ECHEANCE",
+          "amount": -42
+        },
+        {
+          "currency": "EUR",
+          "dates": {
+            "debitedAt": "2026-04-17T12:00:00.000Z"
+          },
+          "description": "PRELEVEMENT CRCAM CENTRE LOIRE 0224392 COTISATION D'ASSURANCE PACIFICA DU CONTRAT AUTOMOBILE 4 ROUES 302023133",
+          "amount": -101.74
+        },
+        {
+          "currency": "EUR",
+          "dates": {
+            "debitedAt": "2026-04-17T12:00:00.000Z"
+          },
+          "description": "PRELVT SEPA RECU D/O CONFRERE PRLV SEPA COFIDIS ICS.FR28ZZZ12211.RUM.80152131E12A SDR102112129",
+          "amount": -50.12
+        },
+        {
+          "currency": "EUR",
+          "dates": {
+            "debitedAt": "2026-04-17T12:00:00.000Z"
+          },
+          "description": "PRLV SEPA CREDIPAR Motif : 101M3323222 32 VOTRE IDEN",
+          "amount": -78.89
+        },
+        {
+          "currency": "EUR",
+          "dates": {
+            "debitedAt": "2026-04-18T12:00:00.000Z"
+          },
+          "description": "Cb 4978******304034 Tot Dif",
+          "amount": -876.34
+        },
+        {
+          "currency": "EUR",
+          "dates": {
+            "debitedAt": "2026-04-19T12:00:00.000Z"
+          },
+          "description": "REGLEMENT ASSU. CNP PRET HABITAT",
+          "amount": -17.8
+        },
+        {
+          "currency": "EUR",
+          "dates": {
+            "debitedAt": "2026-04-19T12:00:00.000Z"
+          },
+          "description": "PRET IMMOBILIER ECH",
+          "amount": -522.31
+        },
+        {
+          "currency": "EUR",
+          "dates": {
+            "debitedAt": "2026-04-20T12:00:00.000Z"
+          },
+          "description": "Cotisation Compte A Composer (rem = 20%)",
+          "amount": -13
+        },
+        {
+          "currency": "EUR",
+          "dates": {
+            "debitedAt": "2026-04-24T12:00:00.000Z"
+          },
+          "description": "CARTE X2517 3-4X CB ONEY. COMMERCE ELECTRONIQUE",
+          "amount": -126.99
+        },
+        {
+          "currency": "EUR",
+          "dates": {
+            "debitedAt": "2026-04-24T12:00:00.000Z"
+          },
+          "description": "PRELEVEMENT DE LUKO COVER SAS REF : 2RQ0IPC LUKO COVER SAS",
+          "amount": -20
+        },
+        {
+          "currency": "EUR",
+          "dates": {
+            "debitedAt": "2026-04-26T12:00:00.000Z"
+          },
+          "description": "AVANCE LARA CROFT VK02101XUZGR9C01",
+          "amount": 500
+        },
+        {
+          "currency": "EUR",
+          "dates": {
+            "debitedAt": "2026-05-03T12:00:00.000Z"
+          },
+          "description": "PRELEVEMENT DE BOUYGUES TELECOM YGUES TELECOM REF : PAGP0102EAAE 06xxxxx687",
+          "amount": -15.99
+        },
+        {
+          "currency": "EUR",
+          "dates": {
+            "debitedAt": "2026-05-11T12:00:00.000Z"
+          },
+          "description": "VIR SEPA RECU /DE NEFAB /MOTIF VIREMENT NEFAB SAS /REF NEFABSAS-0000-082020092555-21",
+          "amount": 2081.45
+        },
+        {
+          "currency": "EUR",
+          "dates": {
+            "debitedAt": "2026-05-12T12:00:00.000Z"
+          },
+          "description": "PRELEVEMENT DE EDF CLIENTS PARTI iers REF : Z012201022 00203 1 S 116",
+          "amount": -102.32
+        },
+        {
+          "currency": "EUR",
+          "dates": {
+            "debitedAt": "2026-05-12T12:00:00.000Z"
+          },
+          "description": "PRLV SEPA BASIC FIT II SA ECH/ID EMETTEUR/FR10ZZ3122 MDT/737001831 REF/NO737001831-106 LIB",
+          "amount": -35.97
+        }
+      ],
+      "type": "CHECKING",
+      "iban": "FR8220041010072288421M03809",
+      "usage": "PERSONAL",
+      "bic": "BNPAFRPPXXX"
+    }
+  ]
+}


### PR DESCRIPTION
**Summary**

Adds a new French sample profile samples/fr/no_owner_name.json covering the edge case where accounts are returned without an owners field (i.e. the bank aggregator did not provide any owner identity for the connected accounts).

This complements the existing edge-case fixtures in samples/fr/ (no_checking_account, ownership_not_supported, account_type_not_supported, currency_not_supported, usage_not_supported, not_enough_transactions) and gives downstream consumers a fixture to validate their handling of missing owner identity.

 **Changes**

  - New file: samples/fr/no_owner_name.json (421 lines) — a full account/transactions payload with no owners block.